### PR TITLE
Fix caption for WN A5

### DIFF
--- a/drupal/content/third-generation-develops.html
+++ b/drupal/content/third-generation-develops.html
@@ -143,7 +143,7 @@ unquade.</p>
 <article class="bullclass">
   <h1 class="bulltitle"><a href="551-x5-0.html">551-X5</a></h1>
   <div class="bullcover"><img typeof="foaf:Image" src="/drupal/sites_bck/default/files/db551X5.png" width="129" height="200" alt="Cover for WN X5" title="Cover for WN X5" /></div>
-  <h2 class="bullsubj">Dozenal Card Games</h2>
+  <h2 class="bullsubj">In Memoriam: Gene Zirkel</h2>
   <h2 class="bulllink"><a href="/drupal/sites_bck/default/files/DuodecimalBulletinIssue551.pdf" type="application/pdf" title="DuodecimalBulletinIssue551.pdf">DuodecimalBulletinIssue551.pdf</a></h2>
 </article>
 


### PR DESCRIPTION
- In the Duodecimal Bulletin Pictorial Synopsis page, corrected the caption for Vol. 55 No. 1, WN A5, to read "In Memoriam: Gene Zirkel"