### PR TITLE
Remove AMDG

### DIFF
--- a/drupal/content/011-00.html
+++ b/drupal/content/011-00.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>011-00 | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/012-01.html
+++ b/drupal/content/012-01.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>012-01 | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/013-02.html
+++ b/drupal/content/013-02.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>013-02 | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/021-03.html
+++ b/drupal/content/021-03.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>021-03 | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/022-04.html
+++ b/drupal/content/022-04.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>022-04 | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/031-05.html
+++ b/drupal/content/031-05.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>031-05 | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/032-06.html
+++ b/drupal/content/032-06.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>032-06 | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/033-07.html
+++ b/drupal/content/033-07.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>033-07 | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/034-08.html
+++ b/drupal/content/034-08.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>034-10 | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/041-09.html
+++ b/drupal/content/041-09.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>041-09 | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/042-0a.html
+++ b/drupal/content/042-0a.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>042-0X | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/043-0b.html
+++ b/drupal/content/043-0b.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>043-0E | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/051-10.html
+++ b/drupal/content/051-10.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>051-10 | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/052-11.html
+++ b/drupal/content/052-11.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>052-11 | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/061-12.html
+++ b/drupal/content/061-12.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>061-12 | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/062-13.html
+++ b/drupal/content/062-13.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>062-13 | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/063-14.html
+++ b/drupal/content/063-14.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>063-14 | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/071-15.html
+++ b/drupal/content/071-15.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>071-15 | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/081-16.html
+++ b/drupal/content/081-16.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>081-16 | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/082-17.html
+++ b/drupal/content/082-17.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>082-17 | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/091-18.html
+++ b/drupal/content/091-18.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>091-18 | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/0e1-1x.html
+++ b/drupal/content/0e1-1x.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>0E1-1X | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/0e2-1e.html
+++ b/drupal/content/0e2-1e.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>0E2-1E | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/0x1-19.html
+++ b/drupal/content/0x1-19.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>0X1-19 | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/101-20.html
+++ b/drupal/content/101-20.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>101-20 | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/101-21.html
+++ b/drupal/content/101-21.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>101-21 | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/111-22.html
+++ b/drupal/content/111-22.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>111-22 | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/112-23.html
+++ b/drupal/content/112-23.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>112-23 | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/121-24.html
+++ b/drupal/content/121-24.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>121-24 | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/122-25.html
+++ b/drupal/content/122-25.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>122-25 | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/131-26.html
+++ b/drupal/content/131-26.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>131-26 | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/132-27.html
+++ b/drupal/content/132-27.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>132-27 | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/141-28.html
+++ b/drupal/content/141-28.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>141-28 | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/142-29.html
+++ b/drupal/content/142-29.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>142-29 | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/151-2x.html
+++ b/drupal/content/151-2x.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>151-2X | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/152-2e.html
+++ b/drupal/content/152-2e.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>152-2E | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/161-30.html
+++ b/drupal/content/161-30.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>161-30 | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/171-31.html
+++ b/drupal/content/171-31.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>171-31 | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/181-32.html
+++ b/drupal/content/181-32.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>181-32 | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/191-33.html
+++ b/drupal/content/191-33.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>191-33 | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/192-34.html
+++ b/drupal/content/192-34.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>192-34 | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/1e1-36.html
+++ b/drupal/content/1e1-36.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>1E1-36 | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/1e2-37.html
+++ b/drupal/content/1e2-37.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>1E2-37 | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/1x0-35.html
+++ b/drupal/content/1x0-35.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>1X0-35 | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/200-38.html
+++ b/drupal/content/200-38.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>200-38 | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/210-39.html
+++ b/drupal/content/210-39.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>210-39 | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/220-3x.html
+++ b/drupal/content/220-3x.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>220-3X | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/230-3e.html
+++ b/drupal/content/230-3e.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>230-3E | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/240-40.html
+++ b/drupal/content/240-40.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>240-40 | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/251-41.html
+++ b/drupal/content/251-41.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>251-41 | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/261-42.html
+++ b/drupal/content/261-42.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>261-42 | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/271-43.html
+++ b/drupal/content/271-43.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>271-43 | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/272-44.html
+++ b/drupal/content/272-44.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>272-44 | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/273-45.html
+++ b/drupal/content/273-45.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>273-45 | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/281-46.html
+++ b/drupal/content/281-46.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>281-46 | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/282-47.html
+++ b/drupal/content/282-47.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>282-47 | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/283-48.html
+++ b/drupal/content/283-48.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>283-48 | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/291-49.html
+++ b/drupal/content/291-49.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>291-49 | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/292-4x.html
+++ b/drupal/content/292-4x.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>292-4X | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/293-4e.html
+++ b/drupal/content/293-4e.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>293-4E | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/2e1-53.html
+++ b/drupal/content/2e1-53.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>2E1-53 | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/2e2-54.html
+++ b/drupal/content/2e2-54.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>2E2-54 | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/2e3-55.html
+++ b/drupal/content/2e3-55.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>2E3-55 | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/2x1-50.html
+++ b/drupal/content/2x1-50.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>2X1-50 | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/2x2-51.html
+++ b/drupal/content/2x2-51.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>2X2-51 | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/2x3-52.html
+++ b/drupal/content/2x3-52.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>2X3-52 | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/301-56.html
+++ b/drupal/content/301-56.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>301-56 | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/302-57.html
+++ b/drupal/content/302-57.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>302-57 | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/303-58.html
+++ b/drupal/content/303-58.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>303-58 | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/311-59.html
+++ b/drupal/content/311-59.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>311-59 | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/312-5x.html
+++ b/drupal/content/312-5x.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>312-5X | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/313-5e.html
+++ b/drupal/content/313-5e.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>313-5E | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/314-60.html
+++ b/drupal/content/314-60.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>314-60 | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/321-61.html
+++ b/drupal/content/321-61.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>321-61 | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/322-62.html
+++ b/drupal/content/322-62.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>322-62 | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/323-63.html
+++ b/drupal/content/323-63.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>323-63 | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/331-64.html
+++ b/drupal/content/331-64.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>331-64 | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/332-65.html
+++ b/drupal/content/332-65.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>332-65 | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/333-66.html
+++ b/drupal/content/333-66.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>333-66 | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/341-67.html
+++ b/drupal/content/341-67.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>341-67 | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/342-68.html
+++ b/drupal/content/342-68.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>342-68 | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/343-69.html
+++ b/drupal/content/343-69.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>343-69 | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/351-6x.html
+++ b/drupal/content/351-6x.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>351-6X | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/352-6e.html
+++ b/drupal/content/352-6e.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>352-6E | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/361-70.html
+++ b/drupal/content/361-70.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>361-70 | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/362-71.html
+++ b/drupal/content/362-71.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>362-71 | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/371-72.html
+++ b/drupal/content/371-72.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>371-72 | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/372-73.html
+++ b/drupal/content/372-73.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>372-73 | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/381-74.html
+++ b/drupal/content/381-74.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>381-74 | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/382-75.html
+++ b/drupal/content/382-75.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>382-75 | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/391-76.html
+++ b/drupal/content/391-76.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>391-76 | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/392-77.html
+++ b/drupal/content/392-77.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>392-77 | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/3e1-7x.html
+++ b/drupal/content/3e1-7x.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>3E1-7X | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/3e2-7e.html
+++ b/drupal/content/3e2-7e.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>3E2-7E | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/3x1-78.html
+++ b/drupal/content/3x1-78.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>3X1-78 | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/3x2-79.html
+++ b/drupal/content/3x2-79.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>3X2-79 | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/401-80.html
+++ b/drupal/content/401-80.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>401-80 | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/402-81.html
+++ b/drupal/content/402-81.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>402-81 | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/411-82.html
+++ b/drupal/content/411-82.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>411-82 | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/412-83.html
+++ b/drupal/content/412-83.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>412-83 | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/421-84.html
+++ b/drupal/content/421-84.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>421-84 | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/422-85.html
+++ b/drupal/content/422-85.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>422-85 | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/431-86.html
+++ b/drupal/content/431-86.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>431-86 | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/432-87.html
+++ b/drupal/content/432-87.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>432-87 | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/441-88.html
+++ b/drupal/content/441-88.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>441-88 | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/442-89.html
+++ b/drupal/content/442-89.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>442-89 | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/451-8x.html
+++ b/drupal/content/451-8x.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>451-8X | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/452-8e.html
+++ b/drupal/content/452-8e.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>452-8E | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/461-90.html
+++ b/drupal/content/461-90.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>461-90 | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/462-91.html
+++ b/drupal/content/462-91.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>462-91 | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/471-92.html
+++ b/drupal/content/471-92.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>471-92 | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/472-93.html
+++ b/drupal/content/472-93.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>472-93 | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/481-94.html
+++ b/drupal/content/481-94.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>481-94 | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/482-95.html
+++ b/drupal/content/482-95.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>482-95 | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/491-96.html
+++ b/drupal/content/491-96.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>491-96 | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/492-97.html
+++ b/drupal/content/492-97.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>492-97 | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/4e1-9x.html
+++ b/drupal/content/4e1-9x.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>4E1-9X | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/4e2-9e.html
+++ b/drupal/content/4e2-9e.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>4E2-9E | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/4x1-98.html
+++ b/drupal/content/4x1-98.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>4X1-98 | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/4x2-99.html
+++ b/drupal/content/4x2-99.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>4X2-99 | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/510-x0.html
+++ b/drupal/content/510-x0.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>510-X0 | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/511-x1-0.html
+++ b/drupal/content/511-x1-0.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>511-X1 | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/521-x2-0.html
+++ b/drupal/content/521-x2-0.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>521-X2 | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/531-x3-0.html
+++ b/drupal/content/531-x3-0.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>531-X3 | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/541-x4-0.html
+++ b/drupal/content/541-x4-0.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>541-X4 | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/551-x5-0.html
+++ b/drupal/content/551-x5-0.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>551-X5 | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/a_dozenal_primer.html
+++ b/drupal/content/a_dozenal_primer.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>A Dozenal Primer | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/about-us.html
+++ b/drupal/content/about-us.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>About Us | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/altbase_asee_resources.html
+++ b/drupal/content/altbase_asee_resources.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>Alternative Base Systems Worksheets | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/analysis-multiplication-tables.html
+++ b/drupal/content/analysis-multiplication-tables.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>Analysis of Multiplication Tables | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/annual-meetings.html
+++ b/drupal/content/annual-meetings.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>Annual Meetings | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/antipatio-al-aritmetiko.html
+++ b/drupal/content/antipatio-al-aritmetiko.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>Antipatio al Aritmetiko | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/articles-and-books.html
+++ b/drupal/content/articles-and-books.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>Articles and Books | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/aspirants-tests.html
+++ b/drupal/content/aspirants-tests.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>The Aspirant<title>Dozenal Society of America | Main Page | Experiment</title>#039;s Tests | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/beard-award-recipients.html
+++ b/drupal/content/beard-award-recipients.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>Beard Award Recipients | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/boxes-cans-some-points-packaging.html
+++ b/drupal/content/boxes-cans-some-points-packaging.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>Boxes <title>Dozenal Society of America | Main Page | Experiment</title>amp; Cans:  Some Points on Packaging | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/brief-introduction-dozenal-counting.html
+++ b/drupal/content/brief-introduction-dozenal-counting.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>A Brief Introduction to Dozenal Counting | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/chord_dialer.html
+++ b/drupal/content/chord_dialer.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>Chord Dialer | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/collected-works-reckoning-reform.html
+++ b/drupal/content/collected-works-reckoning-reform.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>Collected Works on Reckoning Reform | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/contact-us.html
+++ b/drupal/content/contact-us.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>Contact Us | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/converter.html
+++ b/drupal/content/converter.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>A Converter | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/culture-wars-within-and-without.html
+++ b/drupal/content/culture-wars-within-and-without.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>Culture Wars, Within and Without | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/de-arithmetica.html
+++ b/drupal/content/de-arithmetica.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>De Arithmetica | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/de-la-numeracion-que-debe-preferirse.html
+++ b/drupal/content/de-la-numeracion-que-debe-preferirse.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>De la numeracion que debe preferirse. | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/decimal-dozenal-conversion-rules.html
+++ b/drupal/content/decimal-dozenal-conversion-rules.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>Decimal-Dozenal Conversion Rules | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/donate.html
+++ b/drupal/content/donate.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>Donate | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/dozen-properties-number-twelve.html
+++ b/drupal/content/dozen-properties-number-twelve.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>A Dozen Properties of the Number Twelve | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/dozenal-basics-anki-deck-flash-cards.html
+++ b/drupal/content/dozenal-basics-anki-deck-flash-cards.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>Dozenal Basics Anki Deck (Flash Cards) | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/dozenal-calculator.html
+++ b/drupal/content/dozenal-calculator.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>Dozenal and Decimal Scientific Calculator | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/dozenal-divisibility-rules.html
+++ b/drupal/content/dozenal-divisibility-rules.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>Dozenal Divisibility Rules | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/dozenal-divisibility-tests-quick-guide.html
+++ b/drupal/content/dozenal-divisibility-tests-quick-guide.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>Dozenal Divisibility Tests Quick Guide | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/dozenal-frequently-asked-questions.html
+++ b/drupal/content/dozenal-frequently-asked-questions.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>Dozenal Frequently Asked Questions | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/dozenal-home-primes.html
+++ b/drupal/content/dozenal-home-primes.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>Dozenal Home Primes | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/dozenal-mathematical-displays-using-latex.html
+++ b/drupal/content/dozenal-mathematical-displays-using-latex.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>Dozenal Mathematical Displays Using LaTeX | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/dozenal-nomenclature.html
+++ b/drupal/content/dozenal-nomenclature.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>A Dozenal Nomenclature | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/dozenal-oeis-scripts.html
+++ b/drupal/content/dozenal-oeis-scripts.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>Dozenal OEIS Scripts | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/dozenal-solitaire.html
+++ b/drupal/content/dozenal-solitaire.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>Dozenal and Decimal Solitaire Games | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/dozenal-suite.html
+++ b/drupal/content/dozenal-suite.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>dozenal suite | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/dozencalc_app.html
+++ b/drupal/content/dozencalc_app.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>Dozenal Calculator App for Android | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/dozens-vs-tens.html
+++ b/drupal/content/dozens-vs-tens.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>Dozens vs. Tens | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/dozensonline-dozenal-userscripts.html
+++ b/drupal/content/dozensonline-dozenal-userscripts.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>Dozensonline Dozenal Userscripts | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/dozensonline-forum-symbols-debate.html
+++ b/drupal/content/dozensonline-forum-symbols-debate.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>The DozensOnline Forum Symbols Debate | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/dsa-constitution-and-bylaws.html
+++ b/drupal/content/dsa-constitution-and-bylaws.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>DSA Constitution and Bylaws | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/dsa-symbology-synopsis.html
+++ b/drupal/content/dsa-symbology-synopsis.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>The DSA Symbology Synopsis | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/dsa_membership_form.html
+++ b/drupal/content/dsa_membership_form.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>Join the DSA | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/dsa_newscast.html
+++ b/drupal/content/dsa_newscast.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>The DSA Newscast | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/duodecimal-bulletin-historical-summary.html
+++ b/drupal/content/duodecimal-bulletin-historical-summary.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>The Duodecimal Bulletin:  Historical Summary | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/duodecimal-bulletin-pictorial-synopsis.html
+++ b/drupal/content/duodecimal-bulletin-pictorial-synopsis.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>Duodecimal Bulletin:  Pictorial Synopsis | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/duodecimal-bulletin.html
+++ b/drupal/content/duodecimal-bulletin.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>The Duodecimal Bulletin | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/duodecimal-scale.html
+++ b/drupal/content/duodecimal-scale.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>A Duodecimal Scale | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/duodecimal-system-notation.html
+++ b/drupal/content/duodecimal-system-notation.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>The Duodecimal System of Notation | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/duodenal-system-arithmetic-measures-weights-and-coins.html
+++ b/drupal/content/duodenal-system-arithmetic-measures-weights-and-coins.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>Duodenal System of Arithmetic, Measures, Weights and Coins | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/eggsactly-dozen.html
+++ b/drupal/content/eggsactly-dozen.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>Eggsactly a Dozen | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/excursion-numbers.html
+++ b/drupal/content/excursion-numbers.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>An Excursion in Numbers | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/exquisite-analysis-and-dear-friends-lost.html
+++ b/drupal/content/exquisite-analysis-and-dear-friends-lost.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>Exquisite Analysis, and Dear Friends Lost | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/fdroid_clock_app.html
+++ b/drupal/content/fdroid_clock_app.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>Dozenal Clock App for Android | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/featured-figures-basic-operations.html
+++ b/drupal/content/featured-figures-basic-operations.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>Featured Figures:  Basic Operations | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/featured-figures-symbology-overview.html
+++ b/drupal/content/featured-figures-symbology-overview.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>Featured Figures:  Symbology Overview | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/filosofia-de-la-numeracion.html
+++ b/drupal/content/filosofia-de-la-numeracion.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>Filosofia de la numeracion | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/flickering-and-recovery.html
+++ b/drupal/content/flickering-and-recovery.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>Flickering and Recovery | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/foundation-and-first-generation.html
+++ b/drupal/content/foundation-and-first-generation.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>Foundation and First Generation | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/fundamental-operations-duodecimal-system.html
+++ b/drupal/content/fundamental-operations-duodecimal-system.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>Fundamental Operations in the Duodecimal System | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/gautier_la_zonnomie.html
+++ b/drupal/content/gautier_la_zonnomie.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>La Zonnomie | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/going-classic.html
+++ b/drupal/content/going-classic.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>Going Classic | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/history-dsa.html
+++ b/drupal/content/history-dsa.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>A History of the DSA | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/honorary-members-and-fellows-society.html
+++ b/drupal/content/honorary-members-and-fellows-society.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>Honorary Members and Fellows of the Society | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/how-do-you-pronounce-dozenals.html
+++ b/drupal/content/how-do-you-pronounce-dozenals.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>How Do You Pronounce Dozenals? | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/kde-desktop-dozenal-clock.html
+++ b/drupal/content/kde-desktop-dozenal-clock.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>KDE Desktop Dozenal Clock | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/key-dozenal-fractions.html
+++ b/drupal/content/key-dozenal-fractions.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>Key Dozenal Fractions | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/laplace-sur-douzainisme.html
+++ b/drupal/content/laplace-sur-douzainisme.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>Laplace sur Douzainisme | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/latex-package-dozenal.html
+++ b/drupal/content/latex-package-dozenal.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>LaTeX Package:  dozenal | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/leclerc-sur-douzainisme.html
+++ b/drupal/content/leclerc-sur-douzainisme.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>Leclerc sur Douzainisme | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/legranus_numeratione.html
+++ b/drupal/content/legranus_numeratione.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>De Numeratione | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/manual-dozen-system-mods.html
+++ b/drupal/content/manual-dozen-system-mods.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>Manual of the Dozen System (MODS) | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/mathamerica.html
+++ b/drupal/content/mathamerica.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>Mathamerica | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/maximal-repeating-sequence-decimal-expansions-base-twelve.html
+++ b/drupal/content/maximal-repeating-sequence-decimal-expansions-base-twelve.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>On Maximal Repeating Sequence of Decimal Expansions in Base-Twelve | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/media.html
+++ b/drupal/content/media.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title> | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/multiplication-base-twelve.html
+++ b/drupal/content/multiplication-base-twelve.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>Multiplication in Base Twelve | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/multiplication-tables-various-bases.html
+++ b/drupal/content/multiplication-tables-various-bases.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>Multiplication Tables of Various Bases | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/music-scales-and-dozens.html
+++ b/drupal/content/music-scales-and-dozens.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>Music, Scales, and Dozens | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/my-love-affair-dozens.html
+++ b/drupal/content/my-love-affair-dozens.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>My Love Affair with Dozens | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/number-rhyme.html
+++ b/drupal/content/number-rhyme.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>The Number Rhyme | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/numeral-toolbox.html
+++ b/drupal/content/numeral-toolbox.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>A Numeral Toolbox | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/officers-and-board-members.html
+++ b/drupal/content/officers-and-board-members.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>Officers and Board Members | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/online-dozenal-decimal-converter-calculator.html
+++ b/drupal/content/online-dozenal-decimal-converter-calculator.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>Dozenal Society of America | Main Page | Experiment</title>
     <meta charset="UTF-8" />

--- a/drupal/content/opposed-principles.html
+++ b/drupal/content/opposed-principles.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>The Opposed Principles | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/past-board-members.html
+++ b/drupal/content/past-board-members.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>Past Board Members | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/past-officers.html
+++ b/drupal/content/past-officers.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>Past Officers | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/playfair-dozenalism.html
+++ b/drupal/content/playfair-dozenalism.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>Playfair on Dozenalism | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/practical-polygons.html
+++ b/drupal/content/practical-polygons.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>Practical Polygons | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/practice-your-dozenal-arithmetic.html
+++ b/drupal/content/practice-your-dozenal-arithmetic.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>Practice Your Dozenal Arithmetic | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/presentingsymbology.html
+++ b/drupal/content/presentingsymbology.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>Presenting...Symbology | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/questioning-smile-world-wakes-history.html
+++ b/drupal/content/questioning-smile-world-wakes-history.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>Questioning with a Smile as the World Wakes up from History | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/raenbo-dozenals.html
+++ b/drupal/content/raenbo-dozenals.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>RAENBO Dozenals | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/rational-solution-problem-weights-and-measures.html
+++ b/drupal/content/rational-solution-problem-weights-and-measures.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>A Rational Solution to the Problem of Weights and Measures | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/rationality.html
+++ b/drupal/content/rationality.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>Rationality | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/reflections-dsgb.html
+++ b/drupal/content/reflections-dsgb.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>Reflections on the DSGB | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/regional-meetups.html
+++ b/drupal/content/regional-meetups.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>Regional Meetups | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/resources.html
+++ b/drupal/content/resources.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>Resources | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/revised_manual_dozenal_system.html
+++ b/drupal/content/revised_manual_dozenal_system.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>Manual of the Dozenal System | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/schiffman_personality.html
+++ b/drupal/content/schiffman_personality.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>The Personality of the Integers from One to One Gross | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/serene-explorations.html
+++ b/drupal/content/serene-explorations.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>Serene Explorations | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/some-notes-history-and-desirability-using-alternate-number-bases-arithmetic.html
+++ b/drupal/content/some-notes-history-and-desirability-using-alternate-number-bases-arithmetic.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>Some Notes on the History and Desirability of Using Alternate Number Bases in Arithmetic | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/spencer_against_metric.html
+++ b/drupal/content/spencer_against_metric.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>Against the Metric System | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/struggling-entrenchment-decimal-dreaming-it-isnt-so.html
+++ b/drupal/content/struggling-entrenchment-decimal-dreaming-it-isnt-so.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>Struggling with the Entrenchment of Decimal, Dreaming It Isn’t So | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/symbology-overview.html
+++ b/drupal/content/symbology-overview.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>Symbology Overview | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/symbols-symbols-¢-symbols.html
+++ b/drupal/content/symbols-symbols-¢-symbols.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>Symbols, Symbols, !@#$%¢<title>Dozenal Society of America | Main Page | Experiment</title>amp;*(!? Symbols | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/systematic-dozenal-nomenclature.html
+++ b/drupal/content/systematic-dozenal-nomenclature.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>Systematic Dozenal Nomenclature | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/systems-numeration-plea-duodecimal.html
+++ b/drupal/content/systems-numeration-plea-duodecimal.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>Systems of Numeration:  A Plea for the Duodecimal | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/tgm-coherent-dozenal-metrology.html
+++ b/drupal/content/tgm-coherent-dozenal-metrology.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>TGM:  A Coherent Dozenal Metrology | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/tgm_tool_files.html
+++ b/drupal/content/tgm_tool_files.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>TGM Measurement Tools | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/the_duodenary_scale.html
+++ b/drupal/content/the_duodenary_scale.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>The Duodenary Scale | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/third-generation-develops.html
+++ b/drupal/content/third-generation-develops.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>The Third Generation Develops | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/third-generation-enters.html
+++ b/drupal/content/third-generation-enters.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>The Third Generation Enters | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/treisaran-svg-fonts-pitman-characters.html
+++ b/drupal/content/treisaran-svg-fonts-pitman-characters.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>Treisaran SVG Fonts for Pitman Characters | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/troy_trigons.html
+++ b/drupal/content/troy_trigons.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>Trigons to Triads | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/twelve-vs-ten.html
+++ b/drupal/content/twelve-vs-ten.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>Twelve vs. Ten | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/twelves-and-tens.html
+++ b/drupal/content/twelves-and-tens.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>Twelves and Tens | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/uncialclock-deluxe.html
+++ b/drupal/content/uncialclock-deluxe.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>UncialClock Deluxe | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/who-we-are.html
+++ b/drupal/content/who-we-are.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>Who We Are | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/why-change.html
+++ b/drupal/content/why-change.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>Why Change? | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/why-join-society.html
+++ b/drupal/content/why-join-society.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>Why Join the Society? | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/williams_ancient_duodecimal.html
+++ b/drupal/content/williams_ancient_duodecimal.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>An Ancient Duodecimal System | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/wray_naomi_dozenal.html
+++ b/drupal/content/wray_naomi_dozenal.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>Is the decimal system appropriate for modern mathematics? | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/drupal/content/zcalculator.html
+++ b/drupal/content/zcalculator.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>ZCalculator | Dozenal Society of America</title>
     <meta charset="UTF-8" />

--- a/index.html
+++ b/index.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <!-- +AMDG -->
   <head>
     <title>Dozenal Society of America | Main Page | Experiment</title>
     <meta charset="UTF-8" />


### PR DESCRIPTION
- Removed the ubiquitous +AMDG comments.
  This abbreviation stands for "Ad Majorem Dei Gloriam", a Latin phrase translating as "For the Greater Glory of God". This is the motto of the Jesuits, and reflects their ideal of dedicating any actions and endeavors to God. Including this comment was a practice of one of our previous DSA presidents, reflecting his devout Catholicism. The DSA does not discriminate against any religion, but by the same token it should not favor any particular religion, so these comments are not appropriate.